### PR TITLE
Support passing through upper constraints file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Each item should be a dict containing the following items:
   - `public_key_file`: Path to the SSH public key on the control host.
 - `quotas`: Optional dict mapping quota names to their values.
 
+`os_projects_upper_constraints` is a path to an upper constraints file which
+is passed through to the role dependencies.
+
 Dependencies
 ------------
 
@@ -74,6 +77,7 @@ resources.
       roles:
         - role: stackhpc.os-projects
           os_projects_venv: "~/os-projects-venv"
+          os_projects_upper_constraints: "https://opendev.org/openstack/requirements/raw/branch/stable/stein/upper-constraints.txt"
           os_projects_auth_type: "password"
           os_projects_auth:
             project_name: <keystone project>

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,8 @@ galaxy_info:
 dependencies:
   - role: stackhpc.os-shade
     os_shade_venv: "{{ os_projects_venv }}"
+    os_shade_upper_constraints: "{{ os_projects_upper_constraints | default(None) }}"
 
   - role: stackhpc.os-openstackclient
     os_openstackclient_venv: "{{ os_projects_venv }}"
+    os_openstackclient_upper_constraints_file: "{{ os_projects_upper_constraints | default(None) }}"


### PR DESCRIPTION
The role dependencies support an upper constraints file. This change
adds a new variable for setting this on the role dependencies. It is
useful for example when using legacy Python 2.7 environments to prevent
newer releases of libaries being installed which do not support
Python 2.7.