### PR TITLE
Switch from os-shade to os_openstacksdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - ln -s $(pwd) ../stackhpc.os-projects
 
   # Install role dependencies
-  - ansible-galaxy install -p .. stackhpc.os-shade stackhpc.os-openstackclient
+  - ansible-galaxy install -p .. stackhpc.os_openstacksdk stackhpc.os-openstackclient
 
 script:
   # Run Ansible lint against the role

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Each item should be a dict containing the following items:
 Dependencies
 ------------
 
-This role depends on the `stackhpc.os-shade` and `stackhpc.os-openstackclient`
-roles.
+This role depends on the `stackhpc.os_openstacksdk` and
+`stackhpc.os-openstackclient` roles.
 
 Example Playbook
 ----------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,8 +17,8 @@ galaxy_info:
     - openstack
 
 dependencies:
-  - role: stackhpc.os-shade
-    os_shade_venv: "{{ os_projects_venv }}"
+  - role: stackhpc.os_openstacksdk
+    os_openstacksdk_venv: "{{ os_projects_venv }}"
 
   - role: stackhpc.os-openstackclient
     os_openstackclient_venv: "{{ os_projects_venv }}"


### PR DESCRIPTION
Shade is no longer required by ansible modules.