### PR TITLE
Use os_quota module with Ansible 2.8.3 or later

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,8 @@ os_projects_domains: []
 # 'quotas': Optional dict mapping quota names to their values.
 os_projects: []
 
-# Whether to use the os_quota module to define quotas. In existing versions of
-# Ansible this can fail if there is no Cinder endpoint. Set this to true to
-# use the os_quota module rather than the openstack CLI to set quotas.
-os_projects_use_os_quota: false
+# Whether to use the os_quota module to define quotas. In versions of Ansible
+# prior to 2.8.3, this can fail if there is no Cinder endpoint. When supported,
+# we set this to true to use the os_quota module rather than the openstack CLI
+# to set quotas.
+os_projects_use_os_quota: "{{ ansible_version.full >= '2.8.3' | bool }}"


### PR DESCRIPTION
The issue with using os_quota when Cinder is not available [1] is fixed
in all 2.9 releases and starting from 2.8.3 in the 2.8 branch. Start
using os_quota automatically.

[1] https://github.com/ansible/ansible/issues/41240