### PR TITLE
Use versioned Python binary

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set a fact about the Ansible python interpreter
   set_fact:
-    old_ansible_python_interpreter: "{{ ansible_python_interpreter | default('/usr/bin/python') }}"
+    old_ansible_python_interpreter: "{{ ansible_python_interpreter | default('/usr/bin/python' + ansible_python.version.major | string) }}"
 
 - name: Set a fact to ensure Ansible uses the python interpreter in the virtualenv
   set_fact:


### PR DESCRIPTION
On CentOS 8, /usr/bin/python is not available by default. Use a
versioned binary instead, i.e. /usr/bin/python2 or /usr/bin/python3.

Closes #19.