### PR TITLE
Fix Ansible version comparison

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,7 @@ os_projects: []
 # prior to 2.8.3, this can fail if there is no Cinder endpoint. When supported,
 # we set this to true to use the os_quota module rather than the openstack CLI
 # to set quotas.
-os_projects_use_os_quota: "{{ ansible_version.full >= '2.8.3' | bool }}"
+os_projects_use_os_quota: "{{ ansible_version.full is version('2.8.3', '>=') }}"
 
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases.


### PR DESCRIPTION
The previous syntax was doing a simple alphanumeric comparison, so the check worked for 2.9.x but not for 2.10.x.