### PR TITLE
Fix consistent use of API interface

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -239,8 +239,6 @@
 
 # The os_quota module is not available in Ansible 2.2. It will be added in
 # Ansible 2.3, at which point we should use it here.
-# NOTE: We're using --os-interface=public as this is the default for os_*
-# modules and we currently provide no means to override it.
 - name: Ensure quotas are set
   shell: >
     . {{ os_projects_venv }}/bin/activate &&
@@ -254,7 +252,7 @@
     {% if os_projects_cloud is defined %}
     --os-cloud='{{ os_projects_cloud }}'
     {% endif %}
-    --os-interface=public
+    --os-interface={{ os_projects_interface | default('public', true) }}
     quota set {{ item.name }}
     {% for name, value in item.quotas.items() %} --{{ name | replace('_', '-') }}={{ value }}{% endfor %}
   when:


### PR DESCRIPTION
If an API interface has been selected, ensure it is also used for setting project quotas.