### PR TITLE
Workaround for undefined variable

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -15,8 +15,10 @@
   register: os_user_facts_result
 
 - name: Ensure openstack_users is present
-  # Workaround for os_user_facts not setting the openstack_users fact, See:
-  # https://github.com/stackhpc/ansible-role-os-projects/issues/29
+  # os_user_facts has been renamed to os_user_info in ansible>=2.10. 
+  # The module now returns the query result instead of setting a fact.
+  # This exists for backwards compatability with previous ansible releases, 
+  # see: https://github.com/stackhpc/ansible-role-os-projects/issues/29
   set_fact:
     openstack_users: "{{ os_user_facts_results.openstack_users | default([]) }}"
   when:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -12,6 +12,15 @@
     interface: "{{ os_projects_interface | default(omit, true) }}"
     domain: "{{ project.user_domain }}"
   environment: "{{ os_projects_environment }}"
+  register: os_user_facts_result
+
+- name: Ensure openstack_users is present
+  # Workaround for os_user_facts not setting the openstack_users fact, See:
+  # https://github.com/stackhpc/ansible-role-os-projects/issues/29
+  set_fact:
+    openstack_users: "{{ os_user_facts_results.openstack_users | default([]) }}"
+  when:
+    - openstack_users is undefined
 
 - name: Update the user list with the authenticating user
   set_fact:


### PR DESCRIPTION
Kind of seems like an ansible bug or an issue with the os_user_facts module. This might be solved by switching to the openstack collection, but that is a larger piece of work.

Fixes https://github.com/stackhpc/ansible-role-os-projects/issues/29.