### PR TITLE
Switch to newer Ansible and refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ OpenStack using the os\_\* modules.
 Requirements
 ------------
 
-The OpenStack keystone API should be accessible from the target host.
+- Ansible >=2.9
+- The OpenStack keystone API should be accessible from the target host.
 
 Role Variables
 --------------
@@ -64,7 +65,7 @@ Dependencies
 ------------
 
 This role depends on the `stackhpc.os_openstacksdk` and
-`stackhpc.os-openstackclient` roles.
+`stackhpc.os-openstackclient` roles, plus `openstack.cloud` collection.
 
 Example Playbook
 ----------------
@@ -101,7 +102,7 @@ resources.
                   public_key_file: /path/to/key
               quotas:
                 ram: -1
-              
+
 Author Information
 ------------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,12 +44,6 @@ os_projects_domains: []
 # 'quotas': Optional dict mapping quota names to their values.
 os_projects: []
 
-# Whether to use the os_quota module to define quotas. In versions of Ansible
-# prior to 2.8.3, this can fail if there is no Cinder endpoint. When supported,
-# we set this to true to use the os_quota module rather than the openstack CLI
-# to set quotas.
-os_projects_use_os_quota: "{{ ansible_version.full is version('2.8.3', '>=') }}"
-
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases.
 os_projects_upper_constraints: "{% if ansible_python.version.major == 2 %}https://releases.openstack.org/constraints/upper/train{% endif %}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     Role to register projects, users and related resources in OpenStack
   company: StackHPC Ltd
   license: Apache2
-  min_ansible_version: 2.0
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   #role_name: os_projects
   author: Mark Goddard
   description: >
-    Role to register projects, users and related resources in OpenStack
+    Role to register projects, users and related resources in OpenStack.
   company: StackHPC Ltd
   license: Apache2
   min_ansible_version: 2.9
@@ -11,6 +11,10 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
+    - name: Ubuntu
+      versions:
+        - all
   galaxy_tags:
     - cloud
     - keystone

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,32 +8,6 @@
     ansible_python_interpreter: "{{ os_projects_venv ~ '/bin/python' if os_projects_venv != None else old_ansible_python_interpreter }}"
   environment: "{{ os_projects_environment }}"
 
-# The os_quota module is not available in Ansible 2.2. It will be added in
-# Ansible 2.3, at which point we should use it here.
-- name: Ensure quotas are set
-  shell: >
-    . {{ os_projects_venv }}/bin/activate &&
-    openstack
-    {% for auth_name, auth_value in os_projects_admin_auth.items() %}
-    --os-{{ auth_name | replace('_', '-') }}='{{ auth_value }}'
-    {% endfor %}
-    {% if os_projects_cacert is defined %}
-    --os-cacert='{{ os_projects_cacert }}'
-    {% endif %}
-    {% if os_projects_cloud is defined %}
-    --os-cloud='{{ os_projects_cloud }}'
-    {% endif %}
-    --os-interface={{ os_projects_interface | default('public', true) }}
-    quota set {{ item.name }}
-    {% for name, value in item.quotas.items() %} --{{ name | replace('_', '-') }}={{ value }}{% endfor %}
-  when:
-    - not os_projects_use_os_quota | bool
-    - item.quotas is defined
-  with_items: "{{ os_projects }}"
-  environment: "{{ os_projects_environment }}"
-  loop_control:
-    label: "{{ item.name }}"
-
 - name: Ensure openrc environment file exists
   template:
     src: openrc.j2

--- a/tasks/projects.yml
+++ b/tasks/projects.yml
@@ -257,7 +257,6 @@
     volumes: "{{ quotas.volumes | default(omit) }}"
     volumes_lvm: "{{ quotas.volumes_lvm | default(omit) }}"
   when:
-    - os_projects_use_os_quota | bool
     - item.quotas is defined
   with_items: "{{ os_projects }}"
   vars:

--- a/tasks/projects.yml
+++ b/tasks/projects.yml
@@ -218,7 +218,7 @@
   os_quota:
     auth_type: "{{ os_projects_auth_type }}"
     auth: "{{ os_projects_admin_auth }}"
-    cacert: "{{ os_projects_cacert | default(omit) }}"
+    ca_cert: "{{ os_projects_cacert | default(omit) }}"
     cloud: "{{ os_projects_cloud | default(omit) }}"
     interface: "{{ os_projects_interface | default(omit, true) }}"
     name: "{{ item.name }}"
@@ -231,7 +231,6 @@
     floating_ips: "{{ quotas.floating_ips | default(omit) }}"
     floatingip: "{{ quotas.floatingip | default(omit) }}"
     gigabytes: "{{ quotas.gigabytes | default(omit) }}"
-    gigabytes_lvm: "{{ quotas.gigabytes_lvm | default(omit) }}"
     injected_file_size: "{{ quotas.injected_file_size | default(omit) }}"
     injected_files: "{{ quotas.injected_files | default(omit) }}"
     injected_path_size: "{{ quotas.injected_path_size | default(omit) }}"
@@ -251,11 +250,9 @@
     server_group_members: "{{ quotas.server_group_members | default(omit) }}"
     server_groups: "{{ quotas.server_groups | default(omit) }}"
     snapshots: "{{ quotas.snapshots | default(omit) }}"
-    snapshots_lvm: "{{ quotas.snapshots_lvm | default(omit) }}"
     subnet: "{{ quotas.subnet | default(omit) }}"
     subnetpool: "{{ quotas.subnetpool | default(omit) }}"
     volumes: "{{ quotas.volumes | default(omit) }}"
-    volumes_lvm: "{{ quotas.volumes_lvm | default(omit) }}"
   when:
     - item.quotas is defined
   with_items: "{{ os_projects }}"


### PR DESCRIPTION
Drop the old command line workaround. Next step is to add support for quotas per Cinder volume type.

Fixes #36 