### PR TITLE
Prevent use of openstacksdk 0.99.0 breaking compatibility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,5 +45,6 @@ os_projects_domains: []
 os_projects: []
 
 # Use Train upper constraints when running with Python 2, to avoid
-# incompatibility with newer OSC releases.
-os_projects_upper_constraints: "{% if ansible_python.version.major == 2 %}https://releases.openstack.org/constraints/upper/train{% endif %}"
+# incompatibility with newer OSC releases. Use Yoga upper constraints
+# otherwise, to avoid incompatibility with openstacksdk 0.99.0.
+os_projects_upper_constraints: "https://releases.openstack.org/constraints/upper/{% if ansible_python.version.major == 2 %}train{% else %}yoga{% endif %}"


### PR DESCRIPTION
Version 0.99.0 of openstacksdk breaks various Ansible modules, including user creation (the `enabled` field became `is_enabled`).

Use yoga upper constraints to cap openstacksdk to 0.61.0.